### PR TITLE
Remove CA_ID:x prefix from Combat task completion messages

### DIFF
--- a/app/Models/ClanMessage.php
+++ b/app/Models/ClanMessage.php
@@ -84,6 +84,8 @@ class ClanMessage extends Model
         }
 
         if ($this->systemMessageType == "COMBAT_ACHIEVEMENTS" && $settings['combat_achievements'] == "true") {
+            // Remove CA identifier that prefixes the message for some reason on combat tasks.
+            $this->content = str_replace('/(CA_ID:[0-9]+\|)/i', '', $this->content);
             $message .= $this->content;
             return $message;
         }


### PR DESCRIPTION
just psa: I have no clue how php works